### PR TITLE
emmu: Refactor and add verilator testbench

### DIFF
--- a/fpga/src/emmu/dv/dv_emmu_tb.v
+++ b/fpga/src/emmu/dv/dv_emmu_tb.v
@@ -1,0 +1,39 @@
+module dv_emmu_tb;
+
+   reg clk;
+   
+   reg reset;
+   
+   reg 	      go;
+
+   //Clock
+   always
+     #10 clk = ~clk;
+   
+   initial
+     begin
+	$display($time, " << Starting the Simulation >>");
+	#0
+        clk                    = 1'b0;    // at time 0
+	reset                  = 1'b1;    // reset is active
+	#100 
+	  reset    = 1'b0;    // at time 100 release reset
+	#100
+	  go       = 1'b1;	
+	#10000	  
+	  $finish;
+     end	
+
+   //Waveform dump
+   initial
+     begin
+	$dumpfile("test.vcd");
+	$dumpvars(0, dv_emmu);
+     end
+
+
+dv_emmu dv_emmu
+  (.clk (clk),
+   .reset (reset),
+   .go (go));
+endmodule

--- a/fpga/src/emmu/dv/emmu.cpp
+++ b/fpga/src/emmu/dv/emmu.cpp
@@ -1,0 +1,34 @@
+#include <verilated.h>
+#include <verilated_vcd_c.h>
+
+#include "Vdv_emmu__Syms.h"
+
+int main(int argc, char **argv, char **env)
+{
+  Verilated::commandArgs(argc, argv);
+
+  uint64_t t;
+
+  //VCD stuff
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  //char *vcdFileName;
+  Vdv_emmu* top = new Vdv_emmu;
+  top->trace(tfp, 99);
+  tfp->open("test.vcd"/*vcdFileName*/);
+  
+  //Init values
+  top->clk   = 0;
+  top->reset = 1;
+  top->go    = 0;
+  
+  while(t<100000) {
+    if (t==100) top->reset = 0;
+    if (t==10000) top->go = 1;
+    top->eval();
+    top->clk = !top->clk;
+    tfp->dump((vluint64_t)t);
+    t++;
+  }
+  tfp->close();
+}

--- a/fpga/src/emmu/hdl/emmu.v
+++ b/fpga/src/emmu/hdl/emmu.v
@@ -99,7 +99,7 @@ module emmu (/*AUTOARG*/
 
    wire [47:0] 	      emmu_lookup_data;
    wire [63:0] 	      mi_wr_data;
-   wire [5:0] 	      mi_wr_en;
+   wire [7:0] 	      mi_wr_en;
    wire 	      mi_write_low;
    wire 	      mi_write_high;
    
@@ -115,7 +115,7 @@ module emmu (/*AUTOARG*/
    assign mi_write_high = (mi_en & mi_we[0] & (mi_addr[2:0]==3'b100));
    
    //Enabling lower/upper 32 bit data write 
-   assign mi_wr_en[5:0] =  mi_write_low  ? 8'b11110000 :
+   assign mi_wr_en[7:0] =  mi_write_low  ? 8'b11110000 :
 	                   mi_write_high ? 8'b00001111 :
 			                   8'b00000000 ;
    


### PR DESCRIPTION
Testbench is split between the synthesizable transactors and
non-synthesizable parts to allow reuse of transactors in the newly
added verilator test bench